### PR TITLE
Add Player Count History endpoint + improvements

### DIFF
--- a/abattlemetrics/__init__.py
+++ b/abattlemetrics/__init__.py
@@ -1,4 +1,7 @@
 from .client import BattleMetricsClient
+from .datapoint import DataPoint, Resolution
 from .errors import *
 from .player import Player
 from .server import Server
+
+__version__ = '0.0.2'

--- a/abattlemetrics/client.py
+++ b/abattlemetrics/client.py
@@ -171,7 +171,6 @@ class BattleMetricsClient:
         }
 
         payload = await self._request(r, params=params)
-        print(payload)
         data = payload['data']
 
         datapoints = [DataPoint(d['attributes']) for d in data]

--- a/abattlemetrics/client.py
+++ b/abattlemetrics/client.py
@@ -108,9 +108,10 @@ class BattleMetricsClient:
                     log.debug(f'{route.method} {route.url} returned {r.status}')
                     data = await _json_or_text(r)
 
-                    remaining = int(r.headers['X-Rate-Limit-Remaining'])
-                    if remaining == 0:
-                        retry_after = float(r.headers['Retry-After'])
+                    retry_after = r.headers.get('Retry-After', 0)
+                    # NOTE: apparently battlemetrics doesn't always give
+                    # this header
+                    if retry_after:
                         if self.sleep_on_ratelimit:
                             log.warning(f'Rate limited; retrying in {retry_after:.2f}')
                             await asyncio.sleep(retry_after)

--- a/abattlemetrics/client.py
+++ b/abattlemetrics/client.py
@@ -1,4 +1,6 @@
 import asyncio
+import datetime
+import functools
 import logging
 import json
 from typing import Optional
@@ -6,8 +8,10 @@ from urllib.parse import quote
 
 import aiohttp
 
+from .datapoint import DataPoint, Resolution
 from .errors import HTTPException
 from .server import Server
+from . import utils
 
 log = logging.getLogger(__name__)
 
@@ -51,6 +55,24 @@ class _Route:
         self.url = url
 
 
+def alias_param(name, alias):
+    """Alias a keyword parameter in a function.
+    Throws a TypeError when a value is given for both the
+    original kwarg and the alias.
+    """
+    def deco(func):
+        @functools.wraps(func)
+        def wrapper(*args, **kwargs):
+            alias_value = kwargs.get(alias)
+            if alias_value:
+                if name in kwargs:
+                    raise TypeError(f'Cannot pass both {name!r} and {alias!r} in call')
+                kwargs[name] = alias_value
+            return func(*args, **kwargs)
+        return wrapper
+    return deco
+
+
 class BattleMetricsClient:
     """An interface to the battlemetrics API.
 
@@ -90,20 +112,72 @@ class BattleMetricsClient:
                     if remaining == 0:
                         retry_after = float(r.headers['Retry-After'])
                         if self.sleep_on_ratelimit:
-                            log.debug(f'Rate limited; retrying in {retry_after:.2f}')
+                            log.warning(f'Rate limited; retrying in {retry_after:.2f}')
                             await asyncio.sleep(retry_after)
                             log.debug('Done sleeping for rate limit, retrying...')
                             continue
                         else:
+                            e = HTTPException(r)
                             # unlock once rate limit is done
-                            log.debug('Rate limited; raising exception')
+                            log.warning(
+                                'Rate limited; sleep_on_ratelimit '
+                                'is True, raising exception', exc_info=e
+                            )
                             lock.defer(retry_after)
-                            raise HTTPException(r)
+                            raise e
 
                     if r.status != 200:
-                        raise HTTPException(r)
+                        e = HTTPException(r)
+                        log.debug('Response %d caused with:\nHeaders: %s\nParams: %s',
+                                  r.status, headers, params, exc_info=e)
+                        raise e
 
                     return data
+
+            # No more retries left
+            raise HTTPException(r)
+
+    @alias_param('stop', 'before')
+    @alias_param('start', 'after')
+    async def get_player_count_history(
+            self, server_id: int, *,
+            start: datetime.datetime = None, stop: datetime.datetime = None,
+            resolution: Optional[Resolution] = Resolution.RAW):
+        """Obtain a server's player count history.
+
+        Args:
+            server_id (int): The server's id.
+            start (datetime.datetime): Get the player count history after
+                this time. If naive, assumes time is in UTC.
+                This parameter has "after" as an alias.
+            stop (datetime.datetime): Get the player count history before
+                this time. If naive, assumes time is in UTC.
+                This parameter has "before" as an alias.
+            resolution (Optional[Resolution]):
+                The resolution of the data points. If raw, the data points
+                will only have value provided. Any other option will provide
+                value, min, and max.
+
+        Returns:
+            List[DataPoint]: A list of data points sorted by timestamp.
+
+        """
+        r = _Route('GET', '/servers/{server_id}/player-count-history', server_id=server_id)
+
+        params = {
+            'start': utils.isoify_datetime(start),
+            'stop': utils.isoify_datetime(stop),
+            'resolution': resolution.value
+        }
+
+        payload = await self._request(r, params=params)
+        print(payload)
+        data = payload['data']
+
+        datapoints = [DataPoint(d['attributes']) for d in data]
+        datapoints.sort(key=lambda dp: dp.timestamp)
+
+        return datapoints
 
     async def get_server_info(self, server_id: int, *, include_players=False):
         """Obtain server info given an ID.

--- a/abattlemetrics/datapoint.py
+++ b/abattlemetrics/datapoint.py
@@ -1,0 +1,57 @@
+import datetime
+import enum
+from dataclasses import dataclass, field
+from typing import Optional
+
+from .mixins import PayloadIniter
+from . import utils
+
+
+class Resolution(enum.Enum):
+    """The resolution to use when querying DataPoints."""
+    RAW = 'raw'
+    SEVEN_DAYS = 30
+    THIRTY_DAYS = 60
+    SIX_MONTHS = 1440
+
+
+@dataclass(frozen=True, init=False, repr=False)
+class DataPoint(PayloadIniter):
+    """A data point of a time series.
+
+    group (Optional[int]): If multiple groups of metrics were requested,
+        this will be the index of the corresponding group.
+    max (Optional[int]): The minimum value of the datapoint if relevant.
+        This is usually provided when resolution is not raw.
+    min (Optional[int]): The minimum value of the datapoint if relevant.
+        This is usually provided when resolution is not raw.
+    name (Optional[str]): The name of the metric.
+        Only provided when more than one metric is requested.
+    timestamp (datetime.datetime): The data point's timestamp
+        as a naive UTC datetime.
+    value (int): The value of the data point.
+
+    """
+    __init_attrs = ('group', 'min', 'max', 'name', 'value')
+
+    group: Optional[int]
+    min: Optional[int]
+    max: Optional[int]
+    name: Optional[str]
+    timestamp: datetime.datetime
+    value: int
+
+    def __init__(self, payload):
+        self.__init_attrs__(payload, self.__init_attrs, required=False)
+        super().__setattr__('timestamp', utils.parse_datetime(payload['timestamp']))
+        assert self.value is not None, 'payload is missing "value"'
+
+    def __repr__(self):
+        fields = self.__dict__
+        return '{}({})'.format(
+            self.__class__.__name__,
+            ', '.join([
+                f'{name}={value!r}' for name, value in fields.items()
+                if value is not None and not name.startswith('_')
+            ])
+        )

--- a/abattlemetrics/mixins.py
+++ b/abattlemetrics/mixins.py
@@ -2,19 +2,9 @@ import datetime
 from typing import Tuple, Union
 
 
-class DatetimeParser:
-    """A mixin that provides the datetime format used by battlemetrics along
-    with a helper method."""
-    _datetime_format = '%Y-%m-%dT%H:%M:%S.%fZ'
-
-    @classmethod
-    def _parse_datetime(cls, date_string: str) -> datetime.datetime:
-        return datetime.datetime.strptime(date_string, cls._datetime_format)
-
-
 class PayloadIniter:
     """Provides an __init_attrs__ method for extracting attributes
-    from a payload. Use _init_attrs to specify the attributes.
+    from a payload. Use __init_attrs to specify the attributes.
 
     """
 

--- a/abattlemetrics/utils.py
+++ b/abattlemetrics/utils.py
@@ -1,0 +1,16 @@
+import datetime
+
+DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
+
+
+def isoify_datetime(dt: datetime.datetime) -> str:
+    """Turn a datetime into a ISO formatted string in UTC suitable
+    for parameters."""
+    if dt.tzinfo:
+        dt = dt.astimezone(datetime.timezone.utc)
+    return dt.replace(microsecond=0, tzinfo=None).isoformat() + 'Z'
+
+
+def parse_datetime(date_string: str) -> datetime.datetime:
+    """Parse a datetime given by battlemetrics."""
+    return datetime.datetime.strptime(date_string, DATETIME_FORMAT)

--- a/examples/getplayercount.py
+++ b/examples/getplayercount.py
@@ -1,5 +1,7 @@
 import asyncio
+import datetime
 import logging
+from pprint import pprint
 
 import abattlemetrics as abm
 import aiohttp
@@ -14,8 +16,11 @@ log.addHandler(handler)
 async def main():
     async with aiohttp.ClientSession() as session:
         client = abm.BattleMetricsClient(session)
-        server = await client.get_server_info(1234, include_players=True)
-        print(server)
+        # Get the player count history in the last hour
+        start = datetime.datetime.utcnow() - datetime.timedelta(hours=1)
+        stop = datetime.datetime.now().astimezone()
+        datapoints = await client.get_player_count_history(1234, start=start, stop=stop)
+        pprint(datapoints)
 
 
 if __name__ == '__main__':

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = abattlemetrics
-version = 0.0.1
+version = 0.0.2
 description = An async wrapper for the battlemetrics API.
 long_description = file: README.md
 author = thegamecracks


### PR DESCRIPTION
- The Player Count History of a server can now be accessed using `BattleMetricsClient.get_player_count_history(id, start, stop[, resolution])`, returning a list of `DataPoint` objects
  - Adds `examples/getplayercount.py`
- Exposes a read-only view of the raw payload for `Server` and `Player` objects if users need values not provided by the class itself
- Adds package `__version__`
- Fixes logging in `examples/getserver.py`
- Fixes rare bug caused from missing rate limit header