### PR TITLE
Add three endpoints

### DIFF
--- a/abattlemetrics/__init__.py
+++ b/abattlemetrics/__init__.py
@@ -1,7 +1,7 @@
+__version__ = '0.0.3'
+
 from .client import BattleMetricsClient
 from .datapoint import DataPoint, Resolution
 from .errors import *
-from .player import Player
+from .player import IdentifierType, Player
 from .server import Server
-
-__version__ = '0.0.2'

--- a/abattlemetrics/client.py
+++ b/abattlemetrics/client.py
@@ -245,7 +245,6 @@ class BattleMetricsClient:
             stop: datetime.datetime = None
         ) -> List[DataPoint]:
         """Obtain a player's time played history for a server.
-        The values of each datapoint are in seconds.
 
         Start and stop are truncated to the date.
 
@@ -263,6 +262,7 @@ class BattleMetricsClient:
 
         Returns:
             List[DataPoint]: A list of data points sorted by timestamp.
+                Each data point is per day and their values are in seconds.
 
         """
         r = _Route('GET', '/players/{player_id}/time-played-history/{server_id}',

--- a/abattlemetrics/client.py
+++ b/abattlemetrics/client.py
@@ -1,8 +1,10 @@
 import asyncio
 import datetime
 import functools
-import logging
+import inspect
 import json
+import logging
+import sys
 from typing import List, Optional, Union
 from urllib.parse import quote
 
@@ -10,8 +12,10 @@ import aiohttp
 
 from .datapoint import DataPoint, Resolution
 from .errors import HTTPException
+from .limiter import Limiter
+from .player import IdentifierType, Player
 from .server import Server
-from . import utils
+from . import __version__, utils
 
 log = logging.getLogger(__name__)
 
@@ -55,7 +59,7 @@ class _Route:
         self.url = url
 
 
-def alias_param(name, alias):
+def _alias_param(name, alias):
     """Alias a keyword parameter in a function.
     Throws a TypeError when a value is given for both the
     original kwarg and the alias.
@@ -69,6 +73,29 @@ def alias_param(name, alias):
                     raise TypeError(f'Cannot pass both {name!r} and {alias!r} in call')
                 kwargs[name] = alias_value
             return func(*args, **kwargs)
+        return wrapper
+    return deco
+
+
+def _get_my_name():
+    """Get the name of the function that called this."""
+    return inspect.stack()[1].function
+
+
+def _add_bucket(rate, per):
+    """Apply a bucket to check when making an API request."""
+    def deco(func):
+        added_bucket = False
+
+        @functools.wraps(func)
+        def wrapper(self, *args, **kwargs):
+            nonlocal added_bucket
+            if not added_bucket:
+                self._buckets[func.__name__] = Limiter(rate, per)
+                added_bucket = True
+
+            return func(self, *args, **kwargs)
+
         return wrapper
     return deco
 
@@ -90,21 +117,46 @@ class BattleMetricsClient:
         self.session = session
         self.token = token
         self.sleep_on_ratelimit = sleep_on_ratelimit
+        _user_agent = 'https://github.com/thegamecracks/abattlemetrics ({0}) Python/{1[0]}.{1[1]} aiohttp/{2}'
+        self._user_agent = _user_agent.format(__version__, sys.version_info, aiohttp.__version__)
         self._reqlock = asyncio.Lock()
+        self._buckets = {}
 
-    async def _request(self, route: _Route, *, params: Optional[dict] = None):
-        headers = {}
+    async def _request(
+            self, route: _Route, *,
+            bucket: Optional[str] = None,
+            params: Optional[dict] = None,
+            **kwargs):
+        headers = {
+            'User-Agent': self._user_agent
+        }
+
         if self.token:
             headers['Authorization'] = f'Bearer {self.token}'
 
+        if 'json' in kwargs:
+            headers['Content-Type'] = 'application/json'
+            kwargs['data'] = json.dumps(
+                kwargs.pop('json'), separators=(',', ':'), ensure_ascii=True)
+
         if params is None:
             params = {}
+
+        bucket = self._buckets.get(bucket)
+        if bucket is not None:
+            retry_after = bucket.update_rate_limit()
+            if retry_after:
+                log.debug(
+                    '{0.method} {0.url} locally rate limited for {1:.2f}s'.format(
+                        route, retry_after)
+                )
+                await asyncio.sleep(retry_after)
 
         async with _MaybeUnlock(self._reqlock) as lock:
             for tries in range(5):
                 async with self.session.request(
                         route.method, route.url,
-                        headers=headers, params=params) as r:
+                        headers=headers, params=params, **kwargs) as r:
                     log.debug(f'{route.method} {route.url} returned {r.status}')
                     data = await _json_or_text(r)
 
@@ -140,8 +192,8 @@ class BattleMetricsClient:
             # No more retries left
             raise HTTPException(r)
 
-    @alias_param('stop', 'before')
-    @alias_param('start', 'after')
+    @_alias_param('stop', 'before')
+    @_alias_param('start', 'after')
     async def get_player_count_history(
             self, server_id: int, *,
             start: datetime.datetime = None, stop: datetime.datetime = None,
@@ -168,7 +220,8 @@ class BattleMetricsClient:
             List[DataPoint]: A list of data points sorted by timestamp.
 
         """
-        r = _Route('GET', '/servers/{server_id}/player-count-history', server_id=server_id)
+        r = _Route('GET', '/servers/{server_id}/player-count-history',
+                   server_id=int(server_id))
 
         params = {
             'start': utils.isoify_datetime(start),
@@ -184,8 +237,8 @@ class BattleMetricsClient:
 
         return datapoints
 
-    @alias_param('stop', 'before')
-    @alias_param('start', 'after')
+    @_alias_param('stop', 'before')
+    @_alias_param('start', 'after')
     async def get_player_time_played_history(
             self, player_id: int, server_id: int, *,
             start: datetime.datetime = None,
@@ -213,7 +266,7 @@ class BattleMetricsClient:
 
         """
         r = _Route('GET', '/players/{player_id}/time-played-history/{server_id}',
-                   player_id=player_id, server_id=server_id)
+                   player_id=int(player_id), server_id=int(server_id))
 
         params = {
             'start': utils.isoify_datetime(start),
@@ -228,6 +281,59 @@ class BattleMetricsClient:
 
         return datapoints
 
+    @_add_bucket(1, 1)
+    async def match_player(
+            self, identifier: Union[int, str], type: IdentifierType
+        ) -> Optional[int]:
+        """Get the first player that matches a given identifier.
+
+        Requires authentication token with these permissions:
+            RCON:
+                View RCON information
+
+        This endpoint is rate limited to: 1/1s
+
+        Args:
+            identifier (Union[int, str]): An identifier for the player.
+            type (IdentifierType): The type of identifier being provided.
+
+        Returns:
+            int: The player's battlemetrics ID.
+            None: The player could not be found.
+
+        """
+        r = _Route('POST', '/players/match')
+        data = {
+            'data': [
+                {
+                    'type': 'identifier',
+                    'attributes': {
+                        'type': type.value,
+                        'identifier': str(identifier)
+                    }
+                }
+            ]
+        }
+        payload = await self._request(r, json=data, bucket=_get_my_name())
+        data = payload['data']
+        if not data:
+            return
+        return data[0]['relationships']['player']['data']['id']
+
+    async def get_player_info(self, player_id: int) -> Player:
+        """Get a player's info from their battlemetrics ID.
+
+        Args:
+            player_id (int): The player's ID.
+
+        Returns:
+            Player
+
+        """
+        r = _Route('GET', '/players/{player_id}', player_id=int(player_id))
+        payload = await self._request(r)
+        return Player(payload['data'])
+
     async def get_server_info(
             self, server_id: int, *, include_players=False
         ) -> Server:
@@ -238,8 +344,11 @@ class BattleMetricsClient:
             include_players (bool): Whether to also fetch player data.
                 This affects the `players` attribute.
 
+        Returns:
+            Server
+
         """
-        r = _Route('GET', '/servers/{server_id}', server_id=server_id)
+        r = _Route('GET', '/servers/{server_id}', server_id=int(server_id))
 
         params = {}
 

--- a/abattlemetrics/limiter.py
+++ b/abattlemetrics/limiter.py
@@ -1,0 +1,151 @@
+import asyncio
+import math
+import time
+
+
+class Limiter:
+    """An implementation of the leaky bucket algorithm.
+
+    Args:
+        rate (int): The max number of tokens available.
+        per (float): How fast the tokens are restored in seconds.
+
+    """
+    __slots__ = ('rate', 'per', 'leak_rate', '_last', '_tokens')
+
+    def __init__(self, rate, per):
+        self.rate = int(rate)
+        self.per = float(per)
+        self.leak_rate = self.per / self.rate
+        self._last = time.monotonic()
+        self._tokens = rate
+
+    def get_tokens(self, current=None):
+        current = time.monotonic() if current is None else current
+
+        tokens = self._tokens
+
+        if current > self._last + self.per:
+            # Passed window
+            tokens = self.rate
+        else:
+            # Add back any tokens leaked
+            elapsed = current - self._last
+            tokens += int(elapsed // self.leak_rate)
+
+        return tokens
+
+    def get_retry_after(self, current=None, *, _tokens=None):
+        current = time.monotonic() if current is None else current
+
+        tokens = self.get_tokens(current) if _tokens is None else _tokens
+        if tokens:
+            return 0
+
+        elapsed = current - self._last
+        return max(0, self.leak_rate - elapsed)
+
+    def update_rate_limit(self, current=None):
+        current = time.monotonic() if current is None else current
+
+        tokens = self.get_tokens(current)
+
+        retry_after = 0
+        if tokens:
+            self._tokens = tokens - 1
+        else:
+            retry_after = self.get_retry_after(current, _tokens=tokens)
+
+        # Only update _last when a token is leaked
+        if current - self._last > self.leak_rate:
+            self._last = current
+
+        return retry_after
+
+    def reset(self):
+        self._last = time.monotonic()
+        self._tokens = self.rate
+
+
+# class LimitedLock(Limiter):
+#     """A Limiter with an integrated asyncio.Lock.
+# 
+#     This provides methods from both the Limiter and the asyncio.Lock,
+#     and also supports the async context manager.
+#     The internal lock can be accessed via the `lock` attribute.
+# 
+#     The unlock can also be delayed using the defer() method if you
+#     need to enforce a custom retry after time.
+# 
+#     """
+#     __slots__ = ('lock',)
+# 
+#     def __init__(self, *args, **kwargs):
+#         super().__init__(*args, **kwargs)
+# 
+#         lock = asyncio.Lock()
+#         self.lock = lock
+#         self.acquire = lock.acquire
+#         self.release = lock.release
+#         self.locked = lock.locked
+#         self._unlock = True
+# 
+#     async def __aenter__(self):
+#         await self.lock.acquire()
+#         self._unlock = True
+#         self.update_rate_limit()
+# 
+#     def defer(
+#             self, unlock_after: float, *, check_limiter=True
+#         ) -> asyncio.TimerHandle:
+#         """Defer the asyncio.Lock's unlock.
+# 
+#         Args:
+#             unlock_after (float):
+#                 The number of seconds to sleep before unlocking.
+#             check_limiter (bool):
+#                 If True, takes into consideration both the limiter's
+#                 current rate limit and `unlock_after`, and defers
+#                 the lock by the larger of the two.
+#                 This should only be disabled if unlock_after
+#                 was calculated from get_retry_after().
+# 
+#         Returns:
+#             asyncio.TimerHandle
+# 
+#         """
+#         if not self._unlock:
+#             return
+#         self._unlock = False
+# 
+#         if check_limiter:
+#             unlock_after = max(unlock_after, self.get_retry_after())
+# 
+#         loop = asyncio.get_running_loop()
+#         return loop.call_later(unlock_after, self.lock.release)
+# 
+#     async def __aexit__(self, exc_type, exc_val, tb):
+#         retry_after = self.get_retry_after()
+#         if retry_after:
+#             self.defer(retry_after, check_limiter=False)
+#         else:
+#             self.lock.release()
+# 
+#     @classmethod
+#     def from_limiter(cls, rate, per):
+#         return cls(Limiter(rate, per))
+# 
+# 
+# class MockLimitedLock(LimitedLock):
+#     """A mock limited lock with an infinite number of tokens."""
+#     def __init__(self, limiter=None):
+#         super().__init__(Limiter(math.inf, 0))
+# 
+#     def get_tokens(self, current=None):
+#         return math.inf
+# 
+#     def get_retry_after(self, current=None, *, _tokens=None):
+#         return 0
+# 
+#     def update_rate_limit(self, current=None):
+#         return 0

--- a/abattlemetrics/player.py
+++ b/abattlemetrics/player.py
@@ -1,10 +1,35 @@
 from dataclasses import dataclass, field
 import datetime
+import enum
 import types
 from typing import Optional
 
 from .mixins import PayloadIniter
 from . import utils
+
+
+class IdentifierType(enum.Enum):
+    """A player identifier type.
+
+    Types:
+        BE[_LEGACY]_GUID: BattlEye GUID
+
+    """
+    BE_GUID                  = 'BEGUID'
+    BE_LEGACY_GUID           = 'legacyBEGUID'
+    CONAN_CHAR_NAME          = 'conanCharName'
+    EGS_ID                   = 'egsID'
+    FUNCOM_ID                = 'funcomID'
+    IP                       = 'ip'
+    MC_UUID                  = 'mcUUID'
+    NAME                     = 'name'
+    PLAY_FAB_ID              = 'playFabID'
+    STEAM_FAMILY_SHARE_OWNER = 'steamFamilyShareOwner'
+    STEAM_ID                 = 'steamID'
+    SURVIVOR_NAME            = 'survivorName'
+
+    def __repr__(self):
+        return '<{0.__class__.__name__}.{0.name}>'.format(self)
 
 
 @dataclass(frozen=True, init=False)
@@ -43,13 +68,14 @@ class Player(PayloadIniter):
     updated_at: datetime.datetime = field(hash=False, repr=False)
 
     def __init__(self, payload):
-        def flatten_meta():
-            return {x['key']: x['value'] for x in payload['meta']['metadata']}
+        def flatten_meta(metadata):
+            return {x['key']: x['value'] for x in metadata}
 
         super().__setattr__('payload', types.MappingProxyType(payload))
 
         self.__init_attrs__(payload, self.__init_attrs)
-        self.__init_attrs__(flatten_meta(), self._init_meta, required=False)
+        metadata = flatten_meta(payload.get('meta', {}).get('metadata', {}))
+        self.__init_attrs__(metadata, self._init_meta, required=False)
 
         attrs = payload['attributes']
         super().__setattr__('created_at', utils.parse_datetime(attrs['createdAt']))

--- a/examples/getserver.py
+++ b/examples/getserver.py
@@ -4,6 +4,8 @@ import logging
 import abattlemetrics as abm
 import aiohttp
 
+SERVER_ID = 1234
+
 log = logging.getLogger('abattlemetrics')
 log.setLevel(logging.DEBUG)
 handler = logging.FileHandler('abattlemetrics.log', encoding='utf-8', mode='w')
@@ -14,7 +16,7 @@ log.addHandler(handler)
 async def main():
     async with aiohttp.ClientSession() as session:
         client = abm.BattleMetricsClient(session)
-        server = await client.get_server_info(1234, include_players=True)
+        server = await client.get_server_info(SERVER_ID, include_players=True)
         print(server)
 
 

--- a/examples/matchplayeridentifier.py
+++ b/examples/matchplayeridentifier.py
@@ -1,13 +1,13 @@
 import asyncio
 import datetime
 import logging
-from pprint import pprint
 
 import abattlemetrics as abm
 import aiohttp
 
+TOKEN = '<Your token here>'
 PLAYER_ID = 1234
-SERVER_ID = 1234
+PLAYER_ID_TYPE = abm.IdentifierType.STEAM_ID
 
 log = logging.getLogger('abattlemetrics')
 log.setLevel(logging.DEBUG)
@@ -18,13 +18,13 @@ log.addHandler(handler)
 
 async def main():
     async with aiohttp.ClientSession() as session:
-        client = abm.BattleMetricsClient(session)
-        # Get the time played history in the last week
-        stop = datetime.datetime.utcnow()
-        start = stop - datetime.timedelta(weeks=1)
-        datapoints = await client.get_player_time_played_history(
-            PLAYER_ID, SERVER_ID, start=start, stop=stop)
-        pprint(datapoints)
+        client = abm.BattleMetricsClient(session, TOKEN)
+        player_id = await client.match_player(PLAYER_ID, PLAYER_ID_TYPE)
+        if player_id:
+            player = await client.get_player_info(player_id)
+            print(player)
+        else:
+            print('Player not found')
 
 
 if __name__ == '__main__':

--- a/examples/timeplayedhistory.py
+++ b/examples/timeplayedhistory.py
@@ -1,11 +1,13 @@
 import asyncio
 import datetime
 import logging
+import os
 from pprint import pprint
 
 import abattlemetrics as abm
 import aiohttp
 
+PLAYER_ID = 1234
 SERVER_ID = 1234
 
 log = logging.getLogger('abattlemetrics')
@@ -18,10 +20,11 @@ log.addHandler(handler)
 async def main():
     async with aiohttp.ClientSession() as session:
         client = abm.BattleMetricsClient(session)
-        # Get the player count history in the last hour
-        start = datetime.datetime.utcnow() - datetime.timedelta(hours=1)
-        stop = datetime.datetime.now().astimezone()
-        datapoints = await client.get_player_count_history(SERVER_ID, start=start, stop=stop)
+        # Get the time played history in the last week
+        stop = datetime.datetime.utcnow()
+        start = stop - datetime.timedelta(weeks=1)
+        datapoints = await client.get_player_time_played_history(
+            PLAYER_ID, SERVER_ID, start=start, stop=stop)
         pprint(datapoints)
 
 

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = abattlemetrics
-version = 0.0.2
+version = 0.0.3
 description = An async wrapper for the battlemetrics API.
 long_description = file: README.md
 author = thegamecracks


### PR DESCRIPTION
- Adds three new methods to `BattlemetricsClient`
  - `get_player_time_played_history()` (Player Time Played History): Get a history of a player's playtime in a server.
  - `match_player()` (Player Match Identifiers): Obtain the battlemetrics ID of a player from one of their identifiers.
  - `get_player_info()` (Get Player Info): Get a player's info from their battlemetrics ID.
- Adds `IdentifierType` enum
- Adds per-method buckets for endpoints that have their own rate limits, e.g. `match_player()`
- Non-200 responses are now logged as exceptions
- Requests now provide a user agent referring to this repository
- Bump version to 0.0.3