### PR TITLE
Add Player Session History endpoint

### DIFF
--- a/abattlemetrics/__init__.py
+++ b/abattlemetrics/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.1.0'
+__version__ = '0.2.0'
 
 from .client import BattleMetricsClient
 from .datapoint import DataPoint, Resolution

--- a/abattlemetrics/iterators.py
+++ b/abattlemetrics/iterators.py
@@ -1,0 +1,121 @@
+import logging
+from typing import Optional, Union
+import urllib.parse as urlparse
+
+from .session import Session
+from .server import Server
+
+log = logging.getLogger(__name__)
+
+
+class AsyncIterator:
+    async def flatten(self):
+        x = []
+        async for item in self:
+            x.append(item)
+        return x
+
+    async def next(self):
+        raise NotImplementedError
+
+    def __aiter__(self):
+        return self
+
+    async def __anext__(self):
+        return await self.next()
+    
+class AsyncSessionIterator(AsyncIterator):
+    def __init__(
+            self, client, player_id, limit, organization_ids, server_ids,
+            include_servers):
+        self._client = client
+        self._limit = limit
+        self._organization_ids = organization_ids
+        self._server_ids = server_ids
+        self._include_servers = include_servers
+
+        self._route = client._Route(
+            'GET', '/players/{player_id}/relationships/sessions',
+            player_id=player_id
+        )
+        self._current_page = []
+        self._params: Optional[Union[dict, False]] = None
+
+    async def _parse_response(self, r):
+        params = r['links'].get('next', False)
+        if params:
+            params = urlparse.parse_qs(urlparse.urlparse(params).query)
+
+        servers = {
+            payload['attributes']['id']: Server(payload)
+            for payload in r['included']
+            if payload['type'] == 'server'
+        }
+
+        page = []
+        for payload in r['data']:
+            session = Session(payload)
+
+            server = servers.get(session.server_id)
+            if server is not None:
+                super(Session, session).__setattr__('server', server)
+
+            page.append(session)
+
+        # NOTE: is this needed? i.e. does battlemetrics guarantee that
+        # next won't be provided if no data is given?
+        if not page:
+            params = False
+
+        return page, params
+
+    async def next(self):
+        async def request_page(params):
+            log.debug('Requesting %d sessions', params['page[size]'])
+            res = await self._client._request(self._route, params=params)
+            page, params = await self._parse_response(res)
+
+            self._limit -= len(page)
+            if params:
+                if self._limit > 0:
+                    # Update page size so we don't query excess sessions
+                    params['page[size]'] = min(self._limit, 100)
+                else:
+                    # Stop making more requests after this page
+                    params = False
+
+            page.reverse()
+            self._current_page = page
+            self._params = params
+
+        if self._current_page:
+            return self._current_page.pop()
+        elif self._params:
+            # Next page
+            await request_page(self._params)
+        elif self._params is not False:
+            # Initial request
+            params = {
+                'page[size]': min(self._limit, 100)
+            }
+
+            if self._organization_ids:
+                params['filter[organizations]'] = ','.join([
+                    str(n) for n in self._organization_ids])
+            if self._server_ids:
+                params['filter[servers]'] = ','.join([
+                    str(n) for n in self._server_ids])
+
+            include = []
+            if self._include_servers:
+                include.append('server')
+            include = ','.join(include)
+            if include:
+                params['include'] = include
+
+            await request_page(params)
+
+        if self._current_page:
+            return self._current_page.pop()
+        else:
+            raise StopAsyncIteration

--- a/abattlemetrics/server.py
+++ b/abattlemetrics/server.py
@@ -65,11 +65,21 @@ class Server(PayloadIniter):
     def __init__(self, payload):
         super().__setattr__('payload', types.MappingProxyType(payload))
 
-        attrs = payload['data']['attributes']
+        data = payload.get('data')
+        if data:
+            attrs = data['attributes']
+        else:
+            attrs = payload['attributes']
+
         self.__init_attrs__(attrs, self.__init_attrs)
         super().__setattr__('created_at', utils.parse_datetime(attrs['createdAt']))
         super().__setattr__('updated_at', utils.parse_datetime(attrs['updatedAt']))
 
-        players = tuple(Player(item) for item in payload['included']
-                        if item['type'] == 'player')
+        included = payload.get('included')
+        players = ()
+        if included:
+            players = tuple(
+                Player(item) for item in included
+                if item['type'] == 'player'
+            )
         super().__setattr__('players', players)

--- a/abattlemetrics/session.py
+++ b/abattlemetrics/session.py
@@ -1,0 +1,74 @@
+from dataclasses import dataclass, field
+import datetime
+import functools
+import types
+import pprint
+from typing import Optional
+
+from .mixins import PayloadIniter
+from .server import Server
+from . import utils
+
+
+@dataclass(frozen=True, init=False)
+class Session(PayloadIniter):
+    """Represents a player session.
+
+    Attributes:
+    first_time (bool):
+        Whether this is the first time the player is on the server.
+    id (str): The session identifier.
+    player_id (int): The player's ID.
+    player_name (str): The player's name.
+    payload (dict): A read-only view of the raw payload.
+    playtime (float): How long this session has lasted in seconds.
+        If `start` or `stop` is None, then this will be 0.
+    server (Optional[Server]): The server this session took place in.
+        This may be None if the server data was not included.
+    server_id (int): The ID of the server this session took place in.
+    start (Optional[datetime.datetime]):
+        The start of the session as a naive UTC datetime.
+        Battlemetrics may occasionally not provide this date.
+    stop (Optional[datetime.datetime]):
+        The end of the session as a naive UTC datetime.
+        Battlemetrics may occasionally not provide this date.
+
+    """
+    __init_attrs = (
+        {'name': 'first_time', 'path': ('attributes', 'firstTime')},
+        'id',
+        {'name': 'player_id', 'type': int,
+         'path': ('relationships', 'player', 'data', 'id')},
+        {'name': 'player_name', 'path': ('attributes', 'name')},
+        {'name': 'server_id', 'type': int,
+         'path': ('relationships', 'server', 'data', 'id')},
+    )
+
+    first_time: bool                   = field(hash=False, repr=False)
+    id: str
+    payload: dict                      = field(hash=False, repr=False)
+    player_id: int                     = field(hash=False)
+    player_name: str                   = field(hash=False, repr=False)
+    server: Optional[Server]           = field(hash=False, repr=False)
+    server_id: int                     = field(hash=False)
+    start: Optional[datetime.datetime] = field(hash=False, repr=False)
+    stop: Optional[datetime.datetime]  = field(hash=False, repr=False)
+
+    def __init__(self, payload):
+        super().__setattr__('payload', types.MappingProxyType(payload))
+        # NOTE: server is manually assigned by AsyncSessionIterator
+
+        self.__init_attrs__(payload, self.__init_attrs)
+
+        attrs = payload['attributes']
+        start, stop = attrs['start'], attrs['stop']
+        start = utils.parse_datetime(start) if start else None
+        stop = utils.parse_datetime(stop) if stop else None
+        super().__setattr__('start', start)
+        super().__setattr__('stop', stop)
+
+    @functools.cached_property
+    def playtime(self) -> float:
+        if self.start is None or self.stop is None:
+            return 0
+        return (self.stop - self.start).total_seconds()

--- a/examples/sessionhistory.py
+++ b/examples/sessionhistory.py
@@ -1,0 +1,25 @@
+import asyncio
+import datetime
+import logging
+
+import abattlemetrics as abm
+import aiohttp
+
+PLAYER_ID = 1234
+
+log = logging.getLogger('abattlemetrics')
+log.setLevel(logging.DEBUG)
+handler = logging.FileHandler('abattlemetrics.log', encoding='utf-8', mode='w')
+handler.setFormatter(logging.Formatter('%(asctime)s:%(levelname)s:%(name)s: %(message)s'))
+log.addHandler(handler)
+
+
+async def main():
+    async with aiohttp.ClientSession() as session:
+        client = abm.BattleMetricsClient(session)
+        async for s in client.get_player_session_history(PLAYER_ID, limit=1):
+            print(s)
+
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = abattlemetrics
-version = 0.1.0
+version = 0.2.0
 description = An async wrapper for the battlemetrics API.
 long_description = file: README.md
 author = thegamecracks


### PR DESCRIPTION
Adds `Session` dataclass and `BattleMetricsClient.get_player_session_history` method for yielding a player's sessions, along with version bump to 0.2.0.