### PR TITLE
Fix endpoint rate limit caculations

### DIFF
--- a/examples/matchplayeridentifier.py
+++ b/examples/matchplayeridentifier.py
@@ -1,5 +1,4 @@
 import asyncio
-import datetime
 import logging
 
 import abattlemetrics as abm

--- a/examples/sessionhistory.py
+++ b/examples/sessionhistory.py
@@ -1,5 +1,4 @@
 import asyncio
-import datetime
 import logging
 
 import abattlemetrics as abm


### PR DESCRIPTION
Endpoint buckets were updating before the first attempt, not after each attempt, and the bucket was miscalculating the retry after on first usage.
This also removes unnecessary imports in two example scripts.