### PR TITLE
Add Player List endpoint

### DIFF
--- a/abattlemetrics/__init__.py
+++ b/abattlemetrics/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.3.0'
+__version__ = '0.4.0'
 
 from .client import BattleMetricsClient
 from .datapoint import DataPoint, Resolution

--- a/abattlemetrics/errors.py
+++ b/abattlemetrics/errors.py
@@ -12,6 +12,17 @@ class HTTPException(BattleMetricsException):
         status (int): The HTTP status code.
 
     """
-    def __init__(self, response: aiohttp.ClientResponse):
+    def __init__(self, response: aiohttp.ClientResponse, data, *args):
         self.status = response.status
-        super().__init__('{0.status} {0.reason}'.format(response))
+        errors = data.get('errors')
+        detail = None
+        if errors:
+            detail = errors[0]['detail']
+        self.detail = detail
+        super().__init__(
+            '{0.status} {0.reason}{1}'.format(
+                response,
+                f' ({detail})' if detail else ''
+            ),
+            *args
+        )

--- a/abattlemetrics/player.py
+++ b/abattlemetrics/player.py
@@ -9,12 +9,7 @@ from . import utils
 
 
 class IdentifierType(enum.Enum):
-    """A player identifier type.
-
-    Types:
-        BE[_LEGACY]_GUID: BattlEye GUID
-
-    """
+    """A player identifier type."""
     BE_GUID                  = 'BEGUID'
     BE_LEGACY_GUID           = 'legacyBEGUID'
     CONAN_CHAR_NAME          = 'conanCharName'
@@ -47,13 +42,21 @@ class Player(PayloadIniter):
     payload (dict): A read-only view of the raw payload.
     playtime (Optional[float]): How long the player has been in the server
         for their current session in seconds.
+    positive_match (bool):
+        When retrieved from a search with unique identifiers,
+        this will be True if one of those identifiers exactly
+        matches this player.
+    private (bool): Indicates if the profile is private.
+        Private profiles are excluded from search and player lists.
     updated_at (datetime.datetime):
         When this player was last updated as a naive UTC datetime.
 
     """
     __init_attrs = (
         {'name': 'id', 'type': int},
-        {'name': 'name', 'path': ('attributes', 'name')}
+        {'name': 'name', 'path': ('attributes', 'name')},
+        {'name': 'private', 'path': ('attributes', 'private')},
+        {'name': 'positive_match', 'path': ('attributes', 'positiveMatch')}
     )
     _init_meta = ({'name': 'first_time', 'path': 'firstTime'},
                   'score', {'name': 'playtime', 'path': 'time'})
@@ -65,6 +68,8 @@ class Player(PayloadIniter):
     score: Optional[int]          = field(hash=False, repr=False)
     payload: dict                 = field(hash=False, repr=False)
     playtime: Optional[float]     = field(hash=False, repr=False)
+    positive_match: bool          = field(hash=False, repr=False)
+    private: bool                 = field(hash=False, repr=False)
     updated_at: datetime.datetime = field(hash=False, repr=False)
 
     def __init__(self, payload):

--- a/examples/playerlist.py
+++ b/examples/playerlist.py
@@ -1,0 +1,25 @@
+import asyncio
+import logging
+
+import abattlemetrics as abm
+import aiohttp
+
+TOKEN = None
+
+log = logging.getLogger('abattlemetrics')
+log.setLevel(logging.DEBUG)
+handler = logging.FileHandler('abattlemetrics.log', encoding='utf-8', mode='w')
+handler.setFormatter(logging.Formatter('%(asctime)s:%(levelname)s:%(name)s: %(message)s'))
+log.addHandler(handler)
+
+
+async def main():
+    async with aiohttp.ClientSession() as session:
+        client = abm.BattleMetricsClient(session, TOKEN)
+        # Get 5 random players currently online
+        async for p in client.list_players(limit=5, is_online=True):
+            print(p)
+
+
+if __name__ == '__main__':
+    asyncio.run(main())

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = abattlemetrics
-version = 0.3.0
+version = 0.4.0
 description = An async wrapper for the battlemetrics API.
 long_description = file: README.md
 author = thegamecracks


### PR DESCRIPTION
- Adds `BattleMetricsClient.list_players()` method which searches for players according to the parameters
- Adds `detail` attribute to HTTPException
- Adds `positive_match` and `private` attributes to `Player`
- Moves the params creation for `get_player_session_history()` to inside the method itself instead of being in the iterator
- Tweaks documentation for `match_players()`
- Bumps to v0.4.0