### PR TITLE
Add list_players(*, include_identifiers: bool) parameter

### DIFF
--- a/abattlemetrics/__init__.py
+++ b/abattlemetrics/__init__.py
@@ -1,4 +1,4 @@
-__version__ = '0.4.0'
+__version__ = '0.4.1'
 
 from .client import BattleMetricsClient
 from .datapoint import DataPoint, Resolution

--- a/abattlemetrics/client.py
+++ b/abattlemetrics/client.py
@@ -379,7 +379,9 @@ class BattleMetricsClient:
             game (Optional[str]):
                 Filter by this game name.
             include_identifiers (bool): If True, fetches and fills in
-                `identifiers` atttribute for each Player.
+                the `identifiers` atttribute for each Player.
+                For public results, this will only contain identifers
+                of type `IdentifierType.NAME`.
             is_online (Optional[bool]):
                 If True, only return players that are currently online.
             last_seen_after (Optional[datetime.datetime]):

--- a/abattlemetrics/client.py
+++ b/abattlemetrics/client.py
@@ -343,6 +343,7 @@ class BattleMetricsClient:
             first_seen_after: Optional[datetime.datetime] = None,
             first_seen_before: Optional[datetime.datetime] = None,
             game: Optional[str] = None,
+            include_identifiers: bool = False,
             is_online: Optional[bool] = None,
             last_seen_after: Optional[datetime.datetime] = None,
             last_seen_before: Optional[datetime.datetime] = None,
@@ -377,6 +378,8 @@ class BattleMetricsClient:
                 Requires token with "View RCON information" permission.
             game (Optional[str]):
                 Filter by this game name.
+            include_identifiers (bool): If True, fetches and fills in
+                `identifiers` atttribute for each Player.
             is_online (Optional[bool]):
                 If True, only return players that are currently online.
             last_seen_after (Optional[datetime.datetime]):
@@ -432,6 +435,12 @@ class BattleMetricsClient:
             )
         if game:
             params['filter[server][game]'] = str(game)
+
+        include = []
+        if include_identifiers:
+            include.append('identifier')
+        if include:
+            params['include'] = ','.join(include)
         if is_online:
             params['filter[online]'] = 'true'
         if last_seen_after:

--- a/abattlemetrics/iterators.py
+++ b/abattlemetrics/iterators.py
@@ -110,8 +110,13 @@ class AsyncPlayerListIterator(AsyncPaginatedIterator):
                 p_id = int(payload['relationships']['player']['data']['id'])
                 identifiers[p_id].append(payload)
 
-        return [Player(payload, identifiers.get(p_id, None))
-                for payload in r['data']]
+        return [
+            Player(
+                payload,
+                identifiers.get(int(payload['id']), None)
+            )
+            for payload in r['data']
+        ]
 
 
 class AsyncSessionIterator(AsyncPaginatedIterator):

--- a/abattlemetrics/player.py
+++ b/abattlemetrics/player.py
@@ -36,7 +36,10 @@ class Identifier(PayloadIniter):
         Note that this is not the actual player identifier.
     last_seen (datetime.datetime):
         The time this identifier was last seen as a naive UTC datetime.
-    name (str): The player identifier.
+    metadata (dict): A read-only view of the payload metadata.
+        This is supplied for certain identifiers, e.g. IP.
+    name (Optional[str]): The player identifier.
+        This may be None depending on the type, e.g. IP.
     payload (dict): A read-only view of the raw payload.
     player_id (int): The player ID this identifier is associated to.
     private (bool): Indicates if this should be considered private.
@@ -47,7 +50,8 @@ class Identifier(PayloadIniter):
         {'name': 'id', 'type': int},
         {'name': 'last_seen', 'type': utils.parse_datetime,
          'path': ('attributes', 'lastSeen')},
-        {'name': 'name', 'path': ('attributes', 'identifier')},
+        {'name': 'name', 'path': ('attributes', 'identifier'),
+         'default': None},
         {'name': 'player_id', 'type': int,
          'path': ('relationships', 'player', 'data', 'id')},
         {'name': 'private', 'path': ('attributes', 'private')},
@@ -56,6 +60,7 @@ class Identifier(PayloadIniter):
 
     id: int
     last_seen: datetime.datetime  = field(hash=False, repr=False)
+    metadata: dict                = field(hash=False, repr=False)
     name: str                     = field(hash=False)
     payload: dict                 = field(hash=False, repr=False)
     player_id: int                = field(hash=False, repr=False)
@@ -66,6 +71,9 @@ class Identifier(PayloadIniter):
         super().__setattr__('payload', types.MappingProxyType(payload))
 
         self.__init_attrs__(payload, self.__init_attrs)
+
+        metadata = payload['attributes']['metadata'] or {}
+        super().__setattr__('metadata', types.MappingProxyType(metadata))
 
 
 @dataclass(frozen=True, init=False)

--- a/abattlemetrics/server.py
+++ b/abattlemetrics/server.py
@@ -37,11 +37,15 @@ class Server(PayloadIniter):
 
     """
     __init_attrs = (
+        {'name': 'created_at', 'type': utils.parse_datetime,
+         'path': 'createdAt'},
         'address', 'country', 'details', {'name': 'id', 'type': int}, 'ip',
         {'name': 'max_players', 'path': 'maxPlayers'}, 'name',
         {'name': 'player_count', 'path': 'players'}, 'port',
         {'name': 'query_port', 'path': 'portQuery'}, 'private',
-        'rank', 'status'
+        'rank', 'status',
+        {'name': 'updated_at', 'type': utils.parse_datetime,
+         'path': 'updatedAt'}
     )
 
     address: Optional[str]        = field(hash=False, repr=False)
@@ -72,8 +76,6 @@ class Server(PayloadIniter):
             attrs = payload['attributes']
 
         self.__init_attrs__(attrs, self.__init_attrs)
-        super().__setattr__('created_at', utils.parse_datetime(attrs['createdAt']))
-        super().__setattr__('updated_at', utils.parse_datetime(attrs['updatedAt']))
 
         included = payload.get('included')
         players = ()

--- a/abattlemetrics/utils.py
+++ b/abattlemetrics/utils.py
@@ -1,6 +1,6 @@
 import datetime
 
-DATETIME_FORMAT = '%Y-%m-%dT%H:%M:%S.%fZ'
+import dateutil.parser
 
 
 def isoify_datetime(dt: datetime.datetime) -> str:
@@ -13,4 +13,7 @@ def isoify_datetime(dt: datetime.datetime) -> str:
 
 def parse_datetime(date_string: str) -> datetime.datetime:
     """Parse a datetime given by battlemetrics."""
-    return datetime.datetime.strptime(date_string, DATETIME_FORMAT)
+    dt = dateutil.parser.isoparse(date_string)
+    if dt.tzinfo:
+        return dt.astimezone(datetime.timezone.utc).replace(tzinfo=None)
+    return dt

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 aiohttp>=3.7.3,<3.8.0
+python-dateutil==2.8.1

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,6 +1,6 @@
 [metadata]
 name = abattlemetrics
-version = 0.4.0
+version = 0.4.1
 description = An async wrapper for the battlemetrics API.
 long_description = file: README.md
 author = thegamecracks


### PR DESCRIPTION
- Adds `include_identifiers` parameter to `BattleMetricsClient.list_players()` which will fill in the new `identifiers` attribute in each `Player` returned. This new attribute will be a tuple of `Identifier` objects.
- Adds python-dateutil dependency for parsing ISO-8601 datetimes

Other:
- Refactors converting createdAt/updatedAt attributes
- Bumps to v0.4.1