### PR TITLE
Make all datetimes aware and assume local time for naive datetimes

### DIFF
--- a/abattlemetrics/client.py
+++ b/abattlemetrics/client.py
@@ -215,11 +215,11 @@ class BattleMetricsClient:
             server_id (int): The server's ID.
             start (datetime.datetime):
                 Get the player count history after this time.
-                If naive, assumes time is in UTC.
+                Naive datetimes are assumed to be in local time.
                 This parameter has "after" as an alias.
             stop (datetime.datetime):
                 Get the player count history before this time.
-                If naive, assumes time is in UTC.
+                Naive datetimes are assumed to be in local time.
                 This parameter has "before" as an alias.
             resolution (Optional[Resolution]):
                 The resolution of the data points. If raw, the data points
@@ -310,11 +310,11 @@ class BattleMetricsClient:
             server_id (int): The server ID.
             start (datetime.datetime):
                 Get the time played history after this time.
-                If naive, assumes time is in UTC.
+                Naive datetimes are assumed to be in local time.
                 This parameter has "after" as an alias.
             stop (datetime.datetime):
                 Get the time played history before this time.
-                If naive, assumes time is in UTC.
+                Naive datetimes are assumed to be in local time.
                 This parameter has "before" as an alias.
 
         Returns:
@@ -370,12 +370,12 @@ class BattleMetricsClient:
                 Filter by maximum server distance to the client in kilometres.
             first_seen_after (Optional[datetime.datetime]):
                 Filter by players first seen after this datetime.
-                If naive, assumes time is in UTC.
+                Naive datetimes are assumed to be in local time.
                 `server_ids` must also be provided for this parameter.
                 Requires token with "View RCON information" permission.
             first_seen_before (Optional[datetime.datetime]):
                 Filter by players first seen before this datetime.
-                If naive, assumes time is in UTC.
+                Naive datetimes are assumed to be in local time.
                 `server_ids` must also be provided for this parameter.
                 Requires token with "View RCON information" permission.
             game (Optional[str]):
@@ -388,13 +388,13 @@ class BattleMetricsClient:
                 If True, only return players that are currently online.
             last_seen_after (Optional[datetime.datetime]):
                 Filter by players last seen after this datetime.
-                If naive, assumes time is in UTC.
+                Naive datetimes are assumed to be in local time.
             last_seen_before (Optional[datetime.datetime]):
                 Filter by players last seen before this datetime.
-                If naive, assumes time is in UTC.
+                Naive datetimes are assumed to be in local time.
             online_at (Optional[datetime.datetime]):
                 Filter by players being online at this datetime.
-                If naive, assumes time is in UTC.
+                Naive datetimes are assumed to be in local time.
                 `public` must also be False.
             organization_id (Optional[int]):
                 Filter by an organization ID.

--- a/abattlemetrics/datapoint.py
+++ b/abattlemetrics/datapoint.py
@@ -29,8 +29,8 @@ class DataPoint(PayloadIniter):
         This is usually provided when resolution is not raw.
     name (Optional[str]): The name of the metric.
         Only provided when more than one metric is requested.
-    timestamp (datetime.datetime): The data point's timestamp
-        as a naive UTC datetime.
+    timestamp (datetime.datetime):
+        The data point's timestamp as an aware datetime.
     value (int): The value of the data point.
 
     """

--- a/abattlemetrics/errors.py
+++ b/abattlemetrics/errors.py
@@ -14,11 +14,16 @@ class HTTPException(BattleMetricsException):
     """
     def __init__(self, response: aiohttp.ClientResponse, data, *args):
         self.status = response.status
-        errors = data.get('errors')
+
         detail = None
-        if errors:
-            detail = errors[0]['detail']
+        if isinstance(data, dict):
+            errors = data.get('errors')
+            if errors:
+                detail = errors[0]['detail']
+        else:
+            detail = data
         self.detail = detail
+
         super().__init__(
             '{0.status} {0.reason}{1}'.format(
                 response,

--- a/abattlemetrics/player.py
+++ b/abattlemetrics/player.py
@@ -37,7 +37,7 @@ class Identifier(PayloadIniter):
     id (int): The identifier ID.
         Note that this is not the actual player identifier.
     last_seen (datetime.datetime):
-        The time this identifier was last seen as a naive UTC datetime.
+        The time this identifier was last seen as an aware datetime.
     metadata (dict): A read-only view of the payload metadata.
         This is supplied for certain identifiers, e.g. IP.
     name (Optional[str]): The player identifier.
@@ -84,7 +84,7 @@ class Player(PayloadIniter):
 
     Attributes:
     created_at (datetime.datetime): When the player was first created
-        on battlemetrics as a naive UTC datetime.
+        on battlemetrics as an aware datetime.
     first_time (Optional[bool]):
         Whether this is the first time the player is on the server.
     id (int): The player's id.
@@ -103,7 +103,7 @@ class Player(PayloadIniter):
     private (bool): Indicates if the profile is private.
         Private profiles are excluded from search and player lists.
     updated_at (datetime.datetime):
-        When this player was last updated as a naive UTC datetime.
+        When this player was last updated as an aware datetime.
 
     """
     __init_attrs = (

--- a/abattlemetrics/server.py
+++ b/abattlemetrics/server.py
@@ -18,7 +18,7 @@ class Server(PayloadIniter):
     address (Optional[str]): The server address, e.g. play.example.com
     country (str): The country code that the server is hosted in.
     created_at (datetime.datetime):
-        When the server was created on battlemetrics as a naive UTC datetime.
+        When the server was created on battlemetrics as an aware datetime.
     details (dict): A dict with more specific details on the server's settings,
         such as difficulty, map, or game version.
     id (int): The server's ID.
@@ -35,7 +35,7 @@ class Server(PayloadIniter):
     rank (int): The server's rank on battlemetrics's leaderboards.
     status (str): The status of the server, i.e. "online" or "offline"
     updated_at (datetime.datetime):
-        When the server was last updated on battlemetrics as a naive UTC datetime.
+        When the server was last updated on battlemetrics as an aware datetime.
 
     """
     __init_attrs = (

--- a/abattlemetrics/utils.py
+++ b/abattlemetrics/utils.py
@@ -6,8 +6,7 @@ import dateutil.parser
 def isoify_datetime(dt: datetime.datetime) -> str:
     """Turn a datetime into a ISO formatted string in UTC suitable
     for parameters."""
-    if dt.tzinfo:
-        dt = dt.astimezone(datetime.timezone.utc)
+    dt = dt.astimezone(datetime.timezone.utc)
     return dt.replace(microsecond=0, tzinfo=None).isoformat() + 'Z'
 
 
@@ -15,5 +14,5 @@ def parse_datetime(date_string: str) -> datetime.datetime:
     """Parse a datetime given by battlemetrics."""
     dt = dateutil.parser.isoparse(date_string)
     if dt.tzinfo:
-        return dt.astimezone(datetime.timezone.utc).replace(tzinfo=None)
-    return dt
+        return dt.astimezone(datetime.timezone.utc)
+    return dt.replace(tzinfo=datetime.timezone.utc)


### PR DESCRIPTION
Datetimes returned by the API are now made aware, and naive datetimes given are assumed to be in local time. This is to be consistent with ~discord.py cause it's easier that way~ the Python ecosystem.

This also fixes an AttributeError when a non-200 text response is given.